### PR TITLE
Externalize Database Path for Containerized Deployments

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,114 @@
+# Git and version control
+.git
+.gitignore
+.gitattributes
+
+# Python cache and build artifacts
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# Virtual environments
+venv/
+env/
+ENV/
+env.bak/
+venv.bak/
+.venv/
+
+# IDE files
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS generated files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Documentation
+*.md
+docs/
+README*
+
+# Docker files (avoid recursion)
+Dockerfile*
+docker-compose*.yml
+docker-compose*.yaml
+.dockerignore
+
+# Testing
+.pytest_cache/
+.coverage
+htmlcov/
+.tox/
+.nox/
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+
+# Data directories (will be mounted as volumes)
+data/
+logs/
+debug_frames/
+*.db
+*.db-journal
+
+# Environment files
+.env
+.env.local
+.env.*.local
+
+# Temporary files
+*.tmp
+*.temp
+temp/
+tmp/
+
+# Large files and media
+*.mp4
+*.avi
+*.mov
+*.mkv
+*.webm
+*.jpg
+*.jpeg
+*.png
+*.gif
+*.bmp
+*.tiff
+*.svg
+
+# Jupyter notebooks
+.ipynb_checkpoints
+
+# Misc
+.mypy_cache/
+.dmypy.json
+dmypy.json 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,104 @@
+# Score Vision Validator Docker Image
+# Multi-stage build for optimized final image size
+FROM python:3.11-slim-bullseye as builder
+
+# Install build dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    git \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set up Python environment with UV for faster package management
+RUN pip install --no-cache-dir uv
+
+# Create virtual environment in builder stage
+ENV VIRTUAL_ENV=/opt/venv
+RUN python -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+# Install Rust
+ENV RUST_TOOLCHAIN=nightly-2024-09-30
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && \
+    /root/.cargo/bin/rustup toolchain install ${RUST_TOOLCHAIN} && \
+    /root/.cargo/bin/rustup default ${RUST_TOOLCHAIN} && \
+    /root/.cargo/bin/rustup toolchain remove stable
+# Add Cargo installation directory, .local/bin and Omron Venv to PATH
+ENV PATH="/home/$LOCAL_USER/.local/bin:/home/$LOCAL_USER/.cargo/bin:/app/omron_venv/bin:/usr/local/bin:$PATH"
+
+USER $LOCAL_USER
+
+# Copy dependency files  
+COPY pyproject.toml setup.py requirements.txt ./
+
+# Copy source code
+COPY miner/ ./miner/
+COPY validator/ ./validator/
+
+# Install the validator package with all dependencies
+RUN uv pip install --no-cache -e .[validator]
+
+# Production stage
+FROM python:3.11-slim-bullseye as production
+
+# Install runtime dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    # OpenCV dependencies
+    libgl1-mesa-glx \
+    libglib2.0-0 \
+    libsm6 \
+    libxext6 \
+    libxrender-dev \
+    libgomp1 \
+    # Additional system libraries
+    libgcc-s1 \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get clean
+
+# Create non-root user
+ARG APP_USER=validator
+ARG APP_UID=1000
+ARG APP_GID=1000
+
+RUN groupadd -g $APP_GID $APP_USER && \
+    useradd -u $APP_UID -g $APP_GID -m -s /bin/bash $APP_USER
+
+# Copy virtual environment from builder
+COPY --from=builder /opt/venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+
+# Create application directory
+WORKDIR /app
+
+# Copy application source with proper ownership
+COPY --chown=$APP_USER:$APP_USER . .
+
+# Create directories for data persistence
+RUN mkdir -p /app/data /app/logs /app/debug_frames && \
+    chown -R $APP_USER:$APP_USER /app
+
+# Switch to non-root user
+USER $APP_USER
+
+# Set environment variables
+ENV PYTHONPATH="/app"
+ENV PYTHONUNBUFFERED=1
+ENV PYTHONDONTWRITEBYTECODE=1
+
+
+# Health check - simple Python import check
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+    CMD python -c "import sys; sys.exit(0)"
+
+# Default command
+CMD ["python", "-m", "validator.main"]
+
+# Expose port (if needed for metrics/API)
+EXPOSE 8000
+
+# Labels for better image management
+LABEL org.opencontainers.image.title="Score Vision Validator"
+LABEL org.opencontainers.image.description="Soccer Video Analysis Validator for Bittensor Subnet 44"
+LABEL org.opencontainers.image.version="0.3.0"
+LABEL org.opencontainers.image.vendor="Score Vision Team"
+LABEL org.opencontainers.image.source="https://github.com/score-technologies/score-vision" 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,47 @@
+version: '3.8'
+
+services:
+  validator:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: score-vision-validator:latest
+    container_name: score-vision-validator
+    restart: unless-stopped
+    
+    environment:
+      # Required: OpenAI API key
+      OPENAI_API_KEY: ${OPENAI_API_KEY}
+      
+      # Bittensor configuration
+      NETUID: ${NETUID:-44}
+      SUBTENSOR_NETWORK: ${SUBTENSOR_NETWORK:-finney}
+      SUBTENSOR_ADDRESS: ${SUBTENSOR_ADDRESS:-wss://entrypoint-finney.opentensor.ai:443}
+      
+      # Wallet configuration
+      WALLET_NAME: ${WALLET_NAME:-default}
+      HOTKEY_NAME: ${HOTKEY_NAME:-default}
+      
+      # Validator configuration
+      MIN_STAKE_THRESHOLD: ${MIN_STAKE_THRESHOLD:-2}
+      VALIDATOR_PORT: ${VALIDATOR_PORT:-8000}
+      VALIDATOR_HOST: ${VALIDATOR_HOST:-0.0.0.0}
+      
+      # # Database configuration
+      # DB_PATH: ${DB_PATH:-/app/data/validator.db}
+      
+      # Logging
+      LOG_LEVEL: ${LOG_LEVEL:-INFO}
+    
+    volumes:
+      # Data directory
+      - ./data:/app/data
+      # Logs directory
+      - ./logs:/app/logs
+      # Debug frames directory
+      - ./debug_frames:/app/debug_frames
+      # Optional: Mount wallet directory if using local wallets
+      - ${HOME}/.bittensor/wallets:/home/validator/.bittensor/wallets:ro
+    
+    ports:
+      - "8000:8000" 

--- a/env.example
+++ b/env.example
@@ -1,0 +1,89 @@
+# Score Vision Validator Environment Configuration
+# Copy this file to .env and update with your actual values
+
+# =============================================================================
+# REQUIRED CONFIGURATION
+# =============================================================================
+
+# OpenAI API Key (REQUIRED)
+# Get your API key from: https://platform.openai.com/api-keys
+OPENAI_API_KEY=your_openai_api_key_here
+
+# =============================================================================
+# BITTENSOR NETWORK CONFIGURATION
+# =============================================================================
+
+# Network ID for Subnet 44 (Score Vision)
+# - Production mainnet: 44
+# - Testnet: 261
+NETUID=44
+
+# Subtensor network
+# - Production: finney
+# - Testnet: test
+# - Local development: local
+SUBTENSOR_NETWORK=finney
+
+# Subtensor endpoint address
+# - Finney mainnet: wss://entrypoint-finney.opentensor.ai:443
+# - Test network: wss://test.finney.opentensor.ai:443
+# - Local development: ws://127.0.0.1:9944
+SUBTENSOR_ADDRESS=wss://entrypoint-finney.opentensor.ai:443
+
+# =============================================================================
+# WALLET CONFIGURATION
+# =============================================================================
+
+# Bittensor wallet name (must exist in ~/.bittensor/wallets/)
+# This should match the wallet directory name
+WALLET_NAME=default
+
+# Hotkey name within the wallet (must exist in wallet)
+# This should match the hotkey file name without extension
+HOTKEY_NAME=default
+
+# =============================================================================
+# VALIDATOR CONFIGURATION
+# =============================================================================
+
+# Minimum stake threshold for miners (in TAO)
+# Miners below this threshold will be ignored
+MIN_STAKE_THRESHOLD=2
+
+# Validator HTTP server configuration
+# Port for the validator's internal server
+VALIDATOR_PORT=8000
+
+# Host address to bind the validator server
+# Use 0.0.0.0 to accept connections from any interface
+VALIDATOR_HOST=0.0.0.0
+
+# =============================================================================
+# DATABASE CONFIGURATION
+# =============================================================================
+
+# Database file path
+# - Default: validator.db (in current directory)
+# - Custom path: /path/to/your/validator.db
+# DB_PATH=validator.db
+
+# =============================================================================
+# LOGGING CONFIGURATION
+# =============================================================================
+
+# Log level for application logging
+# Options: DEBUG, INFO, WARNING, ERROR, CRITICAL
+# - DEBUG: Detailed information for debugging
+# - INFO: General information about validator operation
+# - WARNING: Warning messages about potential issues
+# - ERROR: Error messages about failures
+LOG_LEVEL=INFO
+
+# =============================================================================
+# RUNTIME VARIABLES
+# =============================================================================
+
+# These variables are set automatically by the validator process
+# You typically don't need to set these manually:
+
+# VALIDATOR_HOTKEY - Set automatically by main.py with loaded hotkey

--- a/validator/config.py
+++ b/validator/config.py
@@ -46,7 +46,9 @@ CHALLENGE_TIMEOUT = timedelta(minutes=4)
 WEIGHTS_INTERVAL = timedelta(minutes=30)
 VALIDATION_DELAY = timedelta(minutes=5)
 
-DB_PATH = Path("validator.db")
+# Database configuration with environment variable support
+DB_PATH = Path(os.getenv("DB_PATH", "validator.db"))
+
 # Log initial configuration
 import logging
 logger = logging.getLogger(__name__)

--- a/validator/main.py
+++ b/validator/main.py
@@ -4,6 +4,7 @@ import os
 import sys
 import time
 import random
+
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Optional, List
@@ -255,10 +256,14 @@ async def get_next_challenge_with_retry(hotkey: str, max_retries: int = 2, initi
     logger.warning("Failed to fetch challenge after all retry attempts")
     return None
 
+
+
 async def main():
     """Main validator loop."""
     # Load configuration
     load_dotenv()
+    
+    logger.info(f"Using database path: {DB_PATH}")
     
     # Get environment variables
     OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")


### PR DESCRIPTION
This PR makes the validator database path configurable via the `DB_PATH` environment variable, enabling easy containerized deployments while maintaining backward compatibility.

## How to Test

**Test default behavior:**
```bash
docker-compose up
# Should use: validator.db (check logs for "Using database path: validator.db")
```

**Test custom database path:**
```bash
# Edit docker-compose.yml to uncomment the DB_PATH line:
# DB_PATH: ${DB_PATH:-/app/data/validator.db}
docker-compose up
# Should use: /app/data/validator.db (check logs for "Using database path: /app/data/validator.db")
```

**Verify it's working:** Look for the log message `"Using database path: [your_path]"` when the validator starts.

## Problem

The database path was hardcoded to `validator.db`, making it difficult to:
- Persist data outside containers
- Use different database locations for dev/staging/prod environments

## Solution

**Docker environment variable configuration:**
```yaml
# docker-compose.yml
services:
  validator:
    environment:
      - DB_PATH=/app/data/validator.db  # Custom path
    volumes:
      - ./data:/app/data
```

## Changes

- **`validator/config.py`**: `DB_PATH = Path(os.getenv("DB_PATH", "validator.db"))`
- **`validator/main.py`**: Simplified database path handling
- **Docker files**: Added `Dockerfile`, `docker-compose.yml`, `.dockerignore`
- **`env.example`**: Environment variable documentation

## Backward Compatibility

✅ **100% backward compatible** - existing deployments continue working unchanged with default `validator.db` path.

## Usage

```bash
# Docker development
docker-compose up

# Custom database path (edit docker-compose.yml)
# Uncomment: DB_PATH: ${DB_PATH:-/app/data/validator.db}
docker-compose up

``` 